### PR TITLE
icanhazJSONheaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ There's no need to check this code out and run it yourself.  These services are 
 
 This is some of the code behind the scenes of some goofy websites like:
 
-* [icanhazip.com](http://icanhazip.com)
-* [icanhazptr.com](http://icanhazptr.com)
-* [icanhaztrace.com](http://icanhaztrace.com)
-* [icanhaztraceroute.com](http://icanhaztraceroute.com)
-* [icanhazepoch.com](http://icanhazepoch.com)
-* [icanhazproxy.com](http://icanhazproxy.com)
+* [icanhazip.com](https://icanhazip.com)
+* [icanhazptr.com](https://icanhazptr.com)
+* [icanhaztrace.com](https://icanhaztrace.com)
+* [icanhaztraceroute.com](https://icanhaztraceroute.com)
+* [icanhazepoch.com](https://icanhazepoch.com)
+* [icanhazproxy.com](https://icanhazproxy.com)
 * [icanhazheaders.com](https://icanhazheaders.com)
 
 It's Apache 2.0 licensed and it's poorly written code. ;)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is some of the code behind the scenes of some goofy websites like:
 * [icanhaztraceroute.com](http://icanhaztraceroute.com)
 * [icanhazepoch.com](http://icanhazepoch.com)
 * [icanhazproxy.com](http://icanhazproxy.com)
+* [icanhazheaders.com](https://icanhazheaders.com)
 
 It's Apache 2.0 licensed and it's poorly written code. ;)
 

--- a/icanhaz.py
+++ b/icanhaz.py
@@ -29,6 +29,7 @@ traceroute_bin = "/bin/traceroute-suid"
 
 @app.route("/")
 def icanhazafunction():
+    mimetype = "text/plain"
     if 'icanhazptr' in request.host:
         # The request is for *.icanhazptr.com
         try:
@@ -84,6 +85,7 @@ def icanhazafunction():
             if value:
                 found_headers[header] = value.strip()
         if len(found_headers) > 0:
+            mimetype = "application/json"
             result = json.dumps(found_headers)
         else:
             return Response(""), 204
@@ -92,7 +94,7 @@ def icanhazafunction():
     else:
         # The request is for *.icanhazip.com or something we don't recognize
         result = request.remote_addr
-    return Response("%s\n" % result, mimetype="text/plain", headers={'X-Your-Ip': request.remote_addr})
+    return Response("%s\n" % result, mimetype=mimetype, headers={"X-Your-Ip": request.remote_addr})
 
 
 @app.route('/crossdomain.xml')


### PR DESCRIPTION
I noticed that [icanhazheaders.com](https://icanhazheaders.com) was returning JSON, but the `Content-Type` was still `text/plain`.

This PR:
- Sets `Content-Type` to `application/json` for `icanhazheaders.com`
- Adds icanhazheaders to README
- Uses https for icanhaz links