### PR TITLE
Set "application/json" for icanhazheaders for realz

### DIFF
--- a/icanhaz.py
+++ b/icanhaz.py
@@ -90,6 +90,7 @@ def icanhazafunction():
         else:
             return Response(""), 204
     elif 'icanhazheaders' in request.host:
+        mimetype = "application/json"
         result = json.dumps(dict(request.headers))
     else:
         # The request is for *.icanhazip.com or something we don't recognize


### PR DESCRIPTION
As pointed out in https://github.com/major/icanhaz/commit/e0a0c8e53caf99f8aa0b9d88ef6a017fd0436663#commitcomment-43820514 , the content type was added for one json.dumps, but not both. This fixes that.